### PR TITLE
Added TestCase and Search By Name/Role

### DIFF
--- a/Zuri-Portfolio-Explore.Tests/Controller/ExploreControllerTests.cs
+++ b/Zuri-Portfolio-Explore.Tests/Controller/ExploreControllerTests.cs
@@ -42,7 +42,7 @@ namespace Zuri_Portfolio_Explore.Tests.Controller
 
         [Theory]
         [InlineData("Jr")]
-        public async void Explore_SearchPortfolio_ReturnOk(string searchTerm)
+        public async void Explore_SearchPortfolioByRole_ReturnOk(string searchTerm)
         {
             //Arrange
             var fPortfolioService = A.Fake<IPortfolioService>();

--- a/Zuri-Portfolio-Explore.Tests/Controller/ExploreControllerTests.cs
+++ b/Zuri-Portfolio-Explore.Tests/Controller/ExploreControllerTests.cs
@@ -1,11 +1,6 @@
 ﻿using FakeItEasy;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Zuri_Portfolio_Explore.Controllers;
 using Zuri_Portfolio_Explore.Domains.DTOs.Response;
 using Zuri_Portfolio_Explore.Repository.Interfaces;
@@ -30,10 +25,10 @@ namespace Zuri_Portfolio_Explore.Tests.Controller
 
             A.CallTo(() => fPortfolioService.GetAllPortfolios()).Returns(Task.FromResult(new ApiResponse<List<PortfolioResponse>>
             {
-                 Data = fPortfolios,
-                 IsSuccessful = true,
-                 Message = "OK",
-                 StatusCode = 200
+                Data = fPortfolios,
+                IsSuccessful = true,
+                Message = "OK",
+                StatusCode = 200
             }));
 
             var controller = new ExploreController(fPortfolioService);
@@ -42,21 +37,32 @@ namespace Zuri_Portfolio_Explore.Tests.Controller
             var result = await controller.GetAllPortfolio();
 
             //Assertions
-            result.Should().NotBeNull().And.BeOfType<OkObjectResult>();  
+            result.Should().NotBeNull().And.BeOfType<OkObjectResult>();
         }
 
-        [Fact]
-        public async void Explore_SearchPortfolio_ReturnOk()
+        [Theory]
+        [InlineData("Jr")]
+        public async void Explore_SearchPortfolio_ReturnOk(string searchTerm)
         {
             //Arrange
-            //var fPortfolioService = A.Fake<IPortfolioService>();
-            //var fPortfolios = A.Fake<List<PortfolioResponse>>();
+            var fPortfolioService = A.Fake<IPortfolioService>();
+            var fPortfolios = A.Fake<List<PortfolioResponse>>();
 
+            A.CallTo(() => fPortfolioService.GetPortfoliosBySearchTerm(searchTerm)).Returns(Task.FromResult(new ApiResponse<List<PortfolioResponse>>
+            {
+                Data = fPortfolios,
+                IsSuccessful = true,
+                Message = "OK",
+                StatusCode = 200
+            }));
 
+            var controller = new ExploreController(fPortfolioService);
 
             //Act
+            var result = await controller.GetPortfoliosBySearchTerm(searchTerm);
 
-            //Assert
+            //Assertions
+            result.Should().NotBeNull().And.BeOfType<OkObjectResult>();
         }
     }
 }

--- a/Zuri-Portfolio-Explore/Controllers/ExploreController.cs
+++ b/Zuri-Portfolio-Explore/Controllers/ExploreController.cs
@@ -21,7 +21,7 @@ namespace Zuri_Portfolio_Explore.Controllers
         }
 
         [HttpGet("search/{searchTerm}")]
-        public async Task<IActionResult> GetAllPortfolioBySearchTerm(string searchTerm)
+        public async Task<IActionResult> GetPortfoliosBySearchTerm(string searchTerm)
         {
             return Ok(await _portfolioService.GetPortfoliosBySearchTerm(searchTerm));
         }

--- a/Zuri-Portfolio-Explore/Domains/Models/User.cs
+++ b/Zuri-Portfolio-Explore/Domains/Models/User.cs
@@ -1,5 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Zuri_Portfolio_Explore.Domains.Models
 {
@@ -48,7 +48,8 @@ namespace Zuri_Portfolio_Explore.Domains.Models
         [Column("created_at")] // Maps to the "created_at" column in the database
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
-        public List<SkillsDetail> SkillDetails {get; set;}
-        public List<Project> Projects {get; set;}
+        public List<SkillsDetail> SkillDetails { get; set; }
+        public List<Project> Projects { get; set; }
+        public UserRoles UserRoles { get; set; }
     }
 }

--- a/Zuri-Portfolio-Explore/Repository/Services/PortfolioService.cs
+++ b/Zuri-Portfolio-Explore/Repository/Services/PortfolioService.cs
@@ -64,8 +64,10 @@ namespace Zuri_Portfolio_Explore.Repository.Services
                 var users = await _context.Users
                     .Include(u => u.SkillDetails)
                     .Include(u => u.Projects)
+                    .Include(u => u.UserRoles)
+                    .ThenInclude(x => x.Role)
                     .Where(x => x.FirstName.ToLower().Contains(searchTerm) || x.LastName.ToLower().Contains(searchTerm)
-                    || x.Username.ToLower().Contains(searchTerm))
+                    || x.Username.ToLower().Contains(searchTerm) || x.UserRoles.Role.Name.ToLower().Contains(searchTerm))
                     .ToListAsync();
 
                 if (users.Count() == 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
Created service and endpoint for searching portfolios by either name or role
​
## Related Issue (Link to linear ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://linear.app/zuri-project-backend/issue/EAG-7/zpe-b07-develop-api-endpoints-for-handling-user-search-queries
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​Adds feature for searching portolio by name or role

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​Yes it has been tested
## Screenshots (if appropriate - Postman, etc):
![Screenshot (24)](https://github.com/hngx-org/team-eagle-zuri-portfolio-explore-backend/assets/64717585/24cb0f14-7e48-4335-bc9f-384afc1c0242)

![Screenshot (25)](https://github.com/hngx-org/team-eagle-zuri-portfolio-explore-backend/assets/64717585/e1089a7f-15df-48ae-9492-8fbf0fcc3a8a)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
